### PR TITLE
Capitalize trait names in the monster embeds

### DIFF
--- a/lib/embeds.py
+++ b/lib/embeds.py
@@ -736,7 +736,7 @@ def generate_monster_embed(monster):
 def generate_caught_monster_embed(name, monster, owner, level, exhausted_timestamp):
     stars = ''.join(['★' for i in range(level)])
     title = name + ' [CR: ' + monster['visual_cr'] + f'] [{stars}]'
-    description = ', '.join([lib.traits.traits[t]['name'] + ' ' + lib.traits.traits[t]['emoji'] for t in monster['traits']])
+    description = ', '.join([lib.traits.traits[t]['name'].capitalize() + ' ' + lib.traits.traits[t]['emoji'] for t in monster['traits']])
     if name != monster['name']:
         description = monster['name'] + ', ' + description
     embed = discord.Embed(title=title, description=description, url=monster['link'])

--- a/lib/embeds.py
+++ b/lib/embeds.py
@@ -716,7 +716,7 @@ def monster_full_title(id, name, type, level, exhausted_timestamp):
 
 def generate_monster_embed(monster):
     title = monster['name'] + ' CR: ' + monster['visual_cr']
-    description = ', '.join([lib.traits.traits[t]['name'] + ' ' + lib.traits.traits[t]['emoji'] for t in monster['traits']])
+    description = ', '.join([lib.traits.traits[t]['name'].capitalize() + ' ' + lib.traits.traits[t]['emoji'] for t in monster['traits']])
     embed = discord.Embed(title=title, description=description, url=monster['link'])
 
     embed.add_field(name='Armor Class', value=monster['ac'], inline=False)


### PR DESCRIPTION
When an user rolls for a monster, the embed doesn't capitalize the traits of the monster